### PR TITLE
Update authentication and api endpoint urls to https.

### DIFF
--- a/src/FlickrAPI.js
+++ b/src/FlickrAPI.js
@@ -33,7 +33,7 @@ module.exports = (function Flickr() {
     }
 
     options = Utils.setAuthVals(options);
-    var   url = "http://api.flickr.com/services/rest",
+    var   url = "https://api.flickr.com/services/rest",
           method = "flickr.auth.oauth.checkToken",
           queryArguments = {
           method: method,

--- a/src/auth/auth.js
+++ b/src/auth/auth.js
@@ -12,7 +12,7 @@ module.exports = (function() {
     options.permissions = options.permissions || "read";
     var oauth_token = options.oauth_token,
         oauth_token_secret = options.oauth_token_secret,
-        authURL = "http://www.flickr.com/services/oauth/authorize",
+        authURL = "https://www.flickr.com/services/oauth/authorize",
         browserURL = authURL + "?oauth_token=" + oauth_token + "&perms=" + options.permissions;
 
     // are we in the browser?

--- a/src/auth/exchange.js
+++ b/src/auth/exchange.js
@@ -30,7 +30,7 @@ module.exports = (function() {
   };
 
   ExchangeTokens.prototype = {
-    url: "http://www.flickr.com/services/oauth/access_token"
+    url: "https://www.flickr.com/services/oauth/access_token"
   };
 
   return ExchangeTokens;

--- a/src/auth/request.js
+++ b/src/auth/request.js
@@ -47,7 +47,7 @@ module.exports = (function() {
   };
 
   RequestTokenFunction.prototype = {
-    url: "http://www.flickr.com/services/oauth/request_token",
+    url: "https://www.flickr.com/services/oauth/request_token",
     formBaseString: function(queryString) {
       return ["GET", encodeURIComponent(this.url), encodeURIComponent(queryString)].join("&");
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -252,7 +252,7 @@ module.exports = (function() {
       // force JSON request
       queryArguments.format = "json";
 
-      var url = "http://ycpi.api.flickr.com/services/rest/",
+      var url = "https://api.flickr.com/services/rest/",
           queryString = this.formQueryString(queryArguments),
           data = this.formBaseString(url, queryString),
           signature = this.sign(data, flickrOptions.secret, flickrOptions.access_token_secret),


### PR DESCRIPTION
We've recently updated our https endpoints for the Flickr API, and we would like API consumers to begin accessing the API via SSL for the benefit of all Flickr users.

I've updated the most important URLs in this commit, authentication and the API endpoint. However it also looks like the client functions are designed to use the protocol of the calling page. I would advise updating those to always call via https as well.
