### PR TITLE
Don't tick progress bar if disabled, causes newline printing.

### DIFF
--- a/src/flickr-api-object.js
+++ b/src/flickr-api-object.js
@@ -28,7 +28,7 @@ module.exports = (function() {
         filename = mdir + "/" + method_name + ".json";
 
     // advance the progress bar
-    if(progressBar) {
+    if(progressBar && flickrOptions.progress) {
         progressBar.tick();
     }
 


### PR DESCRIPTION
Ticking the progress causes console.log() to be called, even when you've explicitly disabled progress bars in the options.