### PR TITLE
Adds RFC5987 and Flickr-specific encoding requirements for query values.

### DIFF
--- a/browser/Utils.js
+++ b/browser/Utils.js
@@ -4,14 +4,21 @@
  * src/utils.js, which heavily relies on being run in Node.js context.
  */
 module.exports = {
-  formQueryString: function(queryArguments) {
-    var args = [],
-        append = function(key) {
-          args.push(key + "=" + encodeURIComponent(queryArguments[key]));
-        };
-    Object.keys(queryArguments).sort().forEach(append);
-    return args.join("&");
-  },
+    encodeRFC5987ValueChars: function(str) {
+      return encodeURIComponent(str).
+      replace(/['()!]/g, escape).
+      replace(/\*/g, '%2A').
+      replace(/%(?:7C|60|5E)/g, unescape);
+    },
+    formQueryString: function(queryArguments) {
+      var Utils = this,
+          args = [],
+          append = function(key) {
+            args.push(key + "=" + Utils.encodeRFC5987ValueChars(queryArguments[key]));
+          };
+      Object.keys(queryArguments).sort().forEach(append);
+      return args.join("&");
+    },
   checkRequirements: function(method_name, required, callOptions, callback) {
     required = required || [];
     for(var r=0, last=required.length, arg; r<last; r++) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -114,18 +114,31 @@ module.exports = (function() {
       return options;
     },
 
-    /**
-     * Collapse a number of oauth query arguments into an
-     * alphabetically sorted, URI-safe concatenated string.
-     */
-    formQueryString: function(queryArguments) {
-      var args = [],
-          append = function(key) {
-            args.push(key + "=" + encodeURIComponent(queryArguments[key]));
-          };
-      Object.keys(queryArguments).sort().forEach(append);
-      return args.join("&");
-    },
+   /**
+    * Properly encode query strings with RFC5987 values.
+    * Additionally, RFC3986 and Flickr require the exclamation point be escaped.
+    * Inspired by MDN: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+    */
+   encodeRFC5987ValueChars: function(str) {
+     return encodeURIComponent(str).
+     replace(/['()!]/g, escape).
+     replace(/\*/g, '%2A').
+     replace(/%(?:7C|60|5E)/g, unescape);
+   },
+
+   /**
+    * Collapse a number of oauth query arguments into an
+    * alphabetically sorted, URI-safe concatenated string.
+    */
+   formQueryString: function(queryArguments) {
+     var Utils = this,
+         args = [],
+         append = function(key) {
+           args.push(key + "=" + Utils.encodeRFC5987ValueChars(queryArguments[key]));
+         };
+     Object.keys(queryArguments).sort().forEach(append);
+     return args.join("&");
+   },
 
     /**
      * Turn a url + query string into a Flickr API "base string".


### PR DESCRIPTION
While writing an app that lets me set the titles and descriptions on photosets, I found that the encoding applied to the querystring for these API requests was not up-to-spec for RFC5987 and Flickr, so they would often fail.

I added a function based on code found in MDN to both the node utils.js and the frontend Utils.js. I could not get the tests to run unfortunately, so I couldn't verify 100% functionality. I also didn't test the frontend at all, but inserted the function where it made the most sense.