### PR TITLE
More future-proof fix for #88

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -311,7 +311,7 @@ module.exports = (function() {
         // for this specific method call.
         if(!error) {
           try {
-            body = body.trim().replace(/^(\/\*\*\/)?jsonFlickrApi\(/,'').replace(/\}\)$/,'}');
+            body = /^[^{]*(\{.+\})[^}]*$/.exec(body.trim())[1];
             body = JSON.parse(body);
             if(body.stat !== "ok") {
               return processResult(new Error(body.message));


### PR DESCRIPTION
This is a fix for issue #88 as an alternative to PR #89.

It finds the response json regardless of what's in front of it. The current fix in #89 will brake if Flickr decides to change the comments again or if they rename the JSONP callback or make any other changes.

The regex in this fix looks for the first `{` and the last `}` and finds the json response like that. It's not _100%_ safe but less likely to brake again.