### PR TITLE
Update request to 2.88.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,11 @@
   "author": "Pomax <pomax@nihongoresources.com>",
   "description": "A Node.js, and client-side, implementation of the Flickr API (for use with an API key, server-side oauth enabled)",
   "dependencies": {
-    "async": "~0.2.10",
     "glob": "~3.2.6",
     "open": "0.0.x",
     "progress": "1.1.4",
     "prompt": "0.2.x",
-    "request": "2.26.x"
+    "request": "2.88.x"
   },
   "devDependencies": {
     "express": "~3.4.7",

--- a/src/handlers/downsync/photos.js
+++ b/src/handlers/downsync/photos.js
@@ -1,5 +1,4 @@
-var async = require("async"),
-    fs = require("fs"),
+var fs = require("fs"),
     download = require("./download").downloadPhoto,
     getSetMetadata = require("./sets"),
     glob = require("glob"),


### PR DESCRIPTION
This fixes a number of critical security issues with request and its
dependencies.

Also, remove the async module since it is not used.